### PR TITLE
removing poster element which caused a thumbnail bug when a video was played

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -788,11 +788,6 @@ jQuery(document).ready(function($) {
             $(videoContainer).externalInterface({method:'removePlayButton'});
         }
         
-        // When a thumb is clicked remove the poster attribute from the video tag
-        $(this).closest('.wd-player')
-                .find('.video-js')
-                .attr('poster',null);
-
         // Set the stage to the current plaing item number. This is so the playlist function knows which video to play next.
         $(this).closest('.wd-player')
                 .find('.wd-stage')

--- a/templates/html5.php
+++ b/templates/html5.php
@@ -1,5 +1,4 @@
 <video id="<?php echo $this->get('attributeId') ?>" class='wd-video-player' src="<?php echo $this->get('link') ?>"
-                        poster="<?php echo $this->get('thumbnail') ?>"
                         width="<?php echo $this->get('width') ?>"
                         height="<?php echo $this->get('height') ?>"
                         preload="none"


### PR DESCRIPTION
The poster element was never getting set to null so every video displayed the thumbnail from the first spot. Removing the attribute entirely means no thumbnail will display when a video is clicked.

Needs to be tested properly before getting merged and resubmitted to wordpress.com.
