### PR TITLE
fixed a bug when hidethumbs was enabled. tag wasn't closed properly.

### DIFF
--- a/templates/thumb_loop.php
+++ b/templates/thumb_loop.php
@@ -56,10 +56,10 @@
 </div>
 <?php endif; ?>
 
-<div class='wd-credits-container
+<div class="wd-credits-container
 <?php if ( count($this->get('items')) == 1 || ($this->get('hidethumbs') == 'on') ) : ?>
  hide-thumbs
-<?php endif; ?>'>
+<?php endif; ?>">
     <div class="wd-credits">
         <span class="wd-title"></span>
         <span class="wd-credit"></span>


### PR DESCRIPTION
Bug only appears when hidethumbs is enabled. Div tag wasn't closed properly because of incorrect quotes, resulting in mangled page source.
